### PR TITLE
Chore: Add blank issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.yml
+++ b/.github/ISSUE_TEMPLATE/blank_issue.yml
@@ -1,0 +1,17 @@
+name: Blank issue
+description: Create a new issue from scratch
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for contributing an issue to our project!
+  - type: markdown
+    attributes:
+      value: |
+        If you are reporting a bug, please use our [Bug Report template](https://github.com/BBeltz1/edab-template/issues/new?template=bug_report.yml). If you are requesting a feature, please use our [Feature Request template](https://github.com/BBeltz1/edab-template/issues/new?template=feature_request.yml).
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+    validations:
+      required: true


### PR DESCRIPTION
### Justification:
All repos created with this template should support user-created issues. In cases where an issue is not a bug report or feature request, the user can use this blank issue template. The only major difference between this template and an untemplated GitHub issue is that the template requires population of the issue body.

### Review instructions:
Check that the commits and changed files included here are appropriate.

### Issues affected:
Closes #12 