### PR TITLE
chore: add issue template config file

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false


### PR DESCRIPTION
### Justification:
This config file will prevent external users from creating an issue without using one of the defined templates. Repo personnel (e.g. admins) will still see the option to use an untemplated blank issue.

### Review instructions:
Check that the commits and changed files included here are appropriate.

### Issues affected:
Closes #10